### PR TITLE
CI by building the action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  buildit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          path: esphome-dlms-meter
+
+      - name: Copy config
+        run: |
+          cp "./esphome-dlms-meter/meter01.example.yaml" "meter01.yaml"
+
+      - name: Build
+        uses: esphome/build-action@v1
+        with:
+          yaml_file: meter01.yaml


### PR DESCRIPTION
Hello,

this PR adds CI by building the action. It uses the example config on ubuntu and the latest esphome to do so.  

Currently this fails due to: https://github.com/DomiStyle/esphome-dlms-meter/issues/22 

If this PR gets merged it will run by every push or pull with the help of GitHub actions: https://github.com/features/actions

The actual building is done with: https://github.com/esphome/build-action

Greetings from Innsbruck