### PR TITLE
Fix Verbose logging

### DIFF
--- a/espdm.cpp
+++ b/espdm.cpp
@@ -519,7 +519,7 @@ namespace esphome
 
         void DlmsMeter::log_packet(std::vector<uint8_t> data)
         {
-            ESP_LOGV(TAG, format_hex_pretty(data).c_str());
+            ESP_LOGV(TAG, "%s", format_hex_pretty(data).c_str());
         }
     }
 }


### PR DESCRIPTION
Initializer fails to determine size of 'pstr'
The F macro expects a string literal, not a variable.